### PR TITLE
prevent reusing ids

### DIFF
--- a/model/Relationships.go
+++ b/model/Relationships.go
@@ -1,18 +1,9 @@
 package model
 
 type ContainsIngredient struct {
-	Unit   string `json:"unit"`
-	Amount int64  `json:"amount"`
+	Unit         string `json:"unit"`
+	Amount       int64  `json:"amount"`
+	IngredientId string `json:"ingredient_id"`
 	// TODO order
-	Relationship
 	Resource
-}
-
-func (l ContainsIngredient) Equal(r ContainsIngredient) bool {
-	return l.Unit == r.Unit && l.Amount == r.Amount && l.TargetId == r.TargetId
-}
-
-type Relationship struct {
-	SourceId *string `json:"source_id"`
-	TargetId string  `json:"target_id"`
 }

--- a/model/Resource.go
+++ b/model/Resource.go
@@ -1,9 +1,44 @@
 package model
 
-import "time"
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ThomasMatlak/food/util"
+)
 
 type Resource struct {
 	Created      *time.Time `json:"created"`
 	LastModified *time.Time `json:"last_modified"`
 	Deleted      *time.Time `json:"deleted"`
+}
+
+func ResourceId(labels []string) (string, error) {
+	filteredLabels := util.FilterArray(labels, func(s string) bool { return len(s) > 0 })
+	if len(filteredLabels) == 0 {
+		return "", errors.New("tried to generate a resource id with an empty list of labels")
+	}
+
+	sort.Strings(filteredLabels)
+	lowerCasedLabels := util.MapArray(filteredLabels, func(s string) string { return strings.ToLower(s) })
+	return fmt.Sprintf("grn:tm-food:%s:%s", strings.Join(lowerCasedLabels, ":"), generateRandomString(10)), nil
+}
+
+func generateRandomString(length int) string { // thanks, chatgpt
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// Create a buffer to hold the generated string
+	buffer := make([]byte, length)
+
+	// Generate a random string by selecting a random character from the charset
+	for i := range buffer {
+		buffer[i] = charset[seededRand.Intn(len(charset))]
+	}
+
+	return string(buffer)
 }

--- a/model/resource_test.go
+++ b/model/resource_test.go
@@ -1,0 +1,59 @@
+package model_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ThomasMatlak/food/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourceId(t *testing.T) {
+	type testCase struct {
+		name           string
+		labels         []string
+		shouldError    bool
+		expectedPrefix string
+	}
+
+	testCases := []testCase{
+		{
+			name:           "Single label",
+			labels:         []string{"Test"},
+			expectedPrefix: "grn:tm-food:test:",
+		},
+		{
+			name:           "Multiple labels",
+			labels:         []string{"Label", "Test"},
+			expectedPrefix: "grn:tm-food:label:test:",
+		},
+		{
+			name:           "Labels should be sorted alphabetically",
+			labels:         []string{"Test", "Resource", "Aardvark"},
+			expectedPrefix: "grn:tm-food:aardvark:resource:test:",
+		},
+		{
+			name:           "Empty strings should be filtered out",
+			labels:         []string{"Test", "Resource", ""},
+			expectedPrefix: "grn:tm-food:resource:test:",
+		},
+		{
+			name:           "Empty lists should cause an error",
+			labels:         []string{},
+			shouldError:    true,
+			expectedPrefix: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := model.ResourceId(tc.labels)
+			if tc.shouldError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.True(t, strings.HasPrefix(id, tc.expectedPrefix))
+		})
+	}
+}

--- a/repository/Relationships.go
+++ b/repository/Relationships.go
@@ -1,14 +1,14 @@
 package repository
 
 import (
-	"strings"
-
 	"github.com/ThomasMatlak/food/model"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 )
 
-func ParseContainsIngredientRelationship(rel dbtype.Relationship) (*model.ContainsIngredient, error) {
+func ParseContainsIngredientRelationship(ingredient *dbtype.Node, rel *dbtype.Relationship) (*model.ContainsIngredient, error) {
+	ingredientId, err := neo4j.GetProperty[string](ingredient, "id")
+
 	unit, err := neo4j.GetProperty[string](rel, "unit")
 	if err != nil {
 		return nil, err
@@ -24,14 +24,5 @@ func ParseContainsIngredientRelationship(rel dbtype.Relationship) (*model.Contai
 		return nil, err
 	}
 
-	relationship := ParseRelationship(rel)
-
-	return &model.ContainsIngredient{Unit: unit, Amount: amount, Relationship: *relationship, Resource: *resource}, nil
-}
-
-func ParseRelationship(rel dbtype.Relationship) *model.Relationship {
-	source := strings.Split(rel.StartElementId, ":")
-	target := strings.Split(rel.EndElementId, ":")
-
-	return &model.Relationship{SourceId: &source[len(source)-1], TargetId: target[len(target)-1]}
+	return &model.ContainsIngredient{Unit: unit, Amount: amount, IngredientId: ingredientId, Resource: *resource}, nil
 }

--- a/util/Array.go
+++ b/util/Array.go
@@ -15,3 +15,13 @@ func MapArray[T, V any](ts []T, fn func(T) V) []V {
 	}
 	return result
 }
+
+func FilterArray[T any](arr []T, fn func(T) bool) []T {
+	result := []T{}
+	for _, a := range arr {
+		if fn(a) {
+			result = append(result, a)
+		}
+	}
+	return result
+}

--- a/util/array_test.go
+++ b/util/array_test.go
@@ -1,11 +1,14 @@
 package util_test
 
 import (
-	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ThomasMatlak/food/util"
+	"github.com/stretchr/testify/assert"
 )
+
+// TODO do generics allow these tests to be nicely put into table-driven sub-tests?
 
 func TestMapAddToInt(t *testing.T) {
 	f := func(x int) int { return x + 1 }
@@ -15,9 +18,7 @@ func TestMapAddToInt(t *testing.T) {
 
 	output := util.MapArray(input, f)
 
-	if !reflect.DeepEqual(output, expectedOutput) {
-		t.Fatalf("mapped output does not match expected values")
-	}
+	assert.Equal(t, expectedOutput, output)
 }
 
 func TestMapExtractStructField(t *testing.T) {
@@ -33,7 +34,29 @@ func TestMapExtractStructField(t *testing.T) {
 
 	output := util.MapArray(input, f)
 
-	if !reflect.DeepEqual(output, expectedOutput) {
-		t.Fatalf("mapped output does not match expected values")
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestFilterArrayInt(t *testing.T) {
+	f := func(x int) bool {
+		return x <= 5
 	}
+
+	input := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	expectedOutput := []int{1, 2, 3, 4, 5}
+
+	output := util.FilterArray(input, f)
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestFilterArrayString(t *testing.T) {
+	f := func(s string) bool {
+		return strings.Contains(s, "test")
+	}
+
+	input := []string{"test value", "value", "t est", "value test"}
+	expectedOutput := []string{"test value", "value test"}
+
+	output := util.FilterArray(input, f)
+	assert.Equal(t, expectedOutput, output)
 }


### PR DESCRIPTION
Previously, ids were derived from the node id.
Neo4j can reuse node ids if a node is deleted, which could eventually lead to problems.

Also simplifies the recipe API response

closes #18 